### PR TITLE
Avoid 'headers send twice', use body parser json handling

### DIFF
--- a/beerlocker-2/server.js
+++ b/beerlocker-2/server.js
@@ -11,6 +11,7 @@ mongoose.connect('mongodb://localhost:27017/beerlocker');
 var app = express();
 
 // Use the body-parser package in our application
+app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({
   extended: true
 }));

--- a/beerlocker-3.1/controllers/beer.js
+++ b/beerlocker-3.1/controllers/beer.js
@@ -14,7 +14,7 @@ exports.postBeers = function(req, res) {
   // Save the beer and check for errors
   beer.save(function(err) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json({ message: 'Beer added to the locker!', data: beer });
   });
@@ -25,7 +25,7 @@ exports.getBeers = function(req, res) {
   // Use the Beer model to find all beer
   Beer.find(function(err, beers) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json(beers);
   });
@@ -36,7 +36,7 @@ exports.getBeer = function(req, res) {
   // Use the Beer model to find a specific beer
   Beer.findById(req.params.beer_id, function(err, beer) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json(beer);
   });
@@ -47,7 +47,7 @@ exports.putBeer = function(req, res) {
   // Use the Beer model to find a specific beer
   Beer.findById(req.params.beer_id, function(err, beer) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     // Update the existing beer quantity
     beer.quantity = req.body.quantity;
@@ -55,7 +55,7 @@ exports.putBeer = function(req, res) {
     // Save the beer and check for errors
     beer.save(function(err) {
       if (err)
-        res.send(err);
+        return res.send(err);
 
       res.json(beer);
     });
@@ -67,7 +67,7 @@ exports.deleteBeer = function(req, res) {
   // Use the Beer model to find a specific beer and remove it
   Beer.findByIdAndRemove(req.params.beer_id, function(err) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json({ message: 'Beer removed from the locker!' });
   });

--- a/beerlocker-3.1/server.js
+++ b/beerlocker-3.1/server.js
@@ -11,6 +11,7 @@ mongoose.connect('mongodb://localhost:27017/beerlocker');
 var app = express();
 
 // Use the body-parser package in our application
+app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({
   extended: true
 }));

--- a/beerlocker-3.2/controllers/beer.js
+++ b/beerlocker-3.2/controllers/beer.js
@@ -15,7 +15,7 @@ exports.postBeers = function(req, res) {
   // Save the beer and check for errors
   beer.save(function(err) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json({ message: 'Beer added to the locker!', data: beer });
   });
@@ -26,7 +26,7 @@ exports.getBeers = function(req, res) {
   // Use the Beer model to find all beer
   Beer.find({ userId: req.user._id }, function(err, beers) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json(beers);
   });
@@ -37,7 +37,7 @@ exports.getBeer = function(req, res) {
   // Use the Beer model to find a specific beer
   Beer.find({ userId: req.user._id, _id: req.params.beer_id }, function(err, beer) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json(beer);
   });
@@ -48,7 +48,7 @@ exports.putBeer = function(req, res) {
   // Use the Beer model to find a specific beer
   Beer.update({ userId: req.user._id, _id: req.params.beer_id }, { quantity: req.body.quantity }, function(err, num, raw) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json({ message: num + ' updated' });
   });
@@ -59,7 +59,7 @@ exports.deleteBeer = function(req, res) {
   // Use the Beer model to find a specific beer and remove it
   Beer.remove({ userId: req.user._id, _id: req.params.beer_id }, function(err) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json({ message: 'Beer removed from the locker!' });
   });

--- a/beerlocker-3.2/controllers/user.js
+++ b/beerlocker-3.2/controllers/user.js
@@ -10,7 +10,7 @@ exports.postUsers = function(req, res) {
 
   user.save(function(err) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json({ message: 'New beer drinker added to the locker room!' });
   });
@@ -20,7 +20,7 @@ exports.postUsers = function(req, res) {
 exports.getUsers = function(req, res) {
   User.find(function(err, users) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json(users);
   });

--- a/beerlocker-3.2/server.js
+++ b/beerlocker-3.2/server.js
@@ -14,6 +14,7 @@ mongoose.connect('mongodb://localhost:27017/beerlocker');
 var app = express();
 
 // Use the body-parser package in our application
+app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({
   extended: true
 }));

--- a/beerlocker-4/controllers/beer.js
+++ b/beerlocker-4/controllers/beer.js
@@ -15,7 +15,7 @@ exports.postBeers = function(req, res) {
   // Save the beer and check for errors
   beer.save(function(err) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json({ message: 'Beer added to the locker!', data: beer });
   });
@@ -26,7 +26,7 @@ exports.getBeers = function(req, res) {
   // Use the Beer model to find all beer
   Beer.find({ userId: req.user._id }, function(err, beers) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json(beers);
   });
@@ -37,7 +37,7 @@ exports.getBeer = function(req, res) {
   // Use the Beer model to find a specific beer
   Beer.find({ userId: req.user._id, _id: req.params.beer_id }, function(err, beer) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json(beer);
   });
@@ -48,7 +48,7 @@ exports.putBeer = function(req, res) {
   // Use the Beer model to find a specific beer
   Beer.update({ userId: req.user._id, _id: req.params.beer_id }, { quantity: req.body.quantity }, function(err, num, raw) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json({ message: num + ' updated' });
   });
@@ -59,7 +59,7 @@ exports.deleteBeer = function(req, res) {
   // Use the Beer model to find a specific beer and remove it
   Beer.remove({ userId: req.user._id, _id: req.params.beer_id }, function(err) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json({ message: 'Beer removed from the locker!' });
   });

--- a/beerlocker-4/controllers/client.js
+++ b/beerlocker-4/controllers/client.js
@@ -15,7 +15,7 @@ exports.postClients = function(req, res) {
   // Save the client and check for errors
   client.save(function(err) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json({ message: 'Client added to the locker!', data: client });
   });
@@ -26,7 +26,7 @@ exports.getClients = function(req, res) {
   // Use the Client model to find all clients
   Client.find({ userId: req.user._id }, function(err, clients) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json(clients);
   });

--- a/beerlocker-4/controllers/user.js
+++ b/beerlocker-4/controllers/user.js
@@ -10,7 +10,7 @@ exports.postUsers = function(req, res) {
 
   user.save(function(err) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json({ message: 'New beer drinker added to the locker room!' });
   });
@@ -20,7 +20,7 @@ exports.postUsers = function(req, res) {
 exports.getUsers = function(req, res) {
   User.find(function(err, users) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json(users);
   });

--- a/beerlocker-4/server.js
+++ b/beerlocker-4/server.js
@@ -21,12 +21,13 @@ var app = express();
 app.set('view engine', 'ejs');
 
 // Use the body-parser package in our application
+app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({
   extended: true
 }));
 
 // Use express session support since OAuth2orize requires it
-app.use(session({ 
+app.use(session({
   secret: 'Super Secret Session Key',
   saveUninitialized: true,
   resave: true

--- a/beerlocker-5/controllers/beer.js
+++ b/beerlocker-5/controllers/beer.js
@@ -15,7 +15,7 @@ exports.postBeers = function(req, res) {
   // Save the beer and check for errors
   beer.save(function(err) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json({ message: 'Beer added to the locker!', data: beer });
   });
@@ -26,7 +26,7 @@ exports.getBeers = function(req, res) {
   // Use the Beer model to find all beer
   Beer.find({ userId: req.user._id }, function(err, beers) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json(beers);
   });
@@ -37,7 +37,7 @@ exports.getBeer = function(req, res) {
   // Use the Beer model to find a specific beer
   Beer.find({ userId: req.user._id, _id: req.params.beer_id }, function(err, beer) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json(beer);
   });
@@ -48,7 +48,7 @@ exports.putBeer = function(req, res) {
   // Use the Beer model to find a specific beer
   Beer.update({ userId: req.user._id, _id: req.params.beer_id }, { quantity: req.body.quantity }, function(err, num, raw) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json({ message: num + ' updated' });
   });
@@ -59,7 +59,7 @@ exports.deleteBeer = function(req, res) {
   // Use the Beer model to find a specific beer and remove it
   Beer.remove({ userId: req.user._id, _id: req.params.beer_id }, function(err) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json({ message: 'Beer removed from the locker!' });
   });

--- a/beerlocker-5/controllers/client.js
+++ b/beerlocker-5/controllers/client.js
@@ -15,7 +15,7 @@ exports.postClients = function(req, res) {
   // Save the client and check for errors
   client.save(function(err) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json({ message: 'Client added to the locker!', data: client });
   });
@@ -26,7 +26,7 @@ exports.getClients = function(req, res) {
   // Use the Client model to find all clients
   Client.find({ userId: req.user._id }, function(err, clients) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json(clients);
   });

--- a/beerlocker-5/controllers/user.js
+++ b/beerlocker-5/controllers/user.js
@@ -10,7 +10,7 @@ exports.postUsers = function(req, res) {
 
   user.save(function(err) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json({ message: 'New beer drinker added to the locker room!' });
   });
@@ -20,7 +20,7 @@ exports.postUsers = function(req, res) {
 exports.getUsers = function(req, res) {
   User.find(function(err, users) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json(users);
   });

--- a/beerlocker-5/server.js
+++ b/beerlocker-5/server.js
@@ -21,12 +21,13 @@ var app = express();
 app.set('view engine', 'ejs');
 
 // Use the body-parser package in our application
+app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({
   extended: true
 }));
 
 // Use express session support since OAuth2orize requires it
-app.use(session({ 
+app.use(session({
   secret: 'Super Secret Session Key',
   saveUninitialized: true,
   resave: true

--- a/beerlocker-6.1/controllers/beer.js
+++ b/beerlocker-6.1/controllers/beer.js
@@ -15,7 +15,7 @@ exports.postBeers = function(req, res) {
   // Save the beer and check for errors
   beer.save(function(err) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json({ message: 'Beer added to the locker!', data: beer });
   });
@@ -26,7 +26,7 @@ exports.getBeers = function(req, res) {
   // Use the Beer model to find all beer
   Beer.find({ userId: req.user._id }, function(err, beers) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json(beers);
   });
@@ -37,7 +37,7 @@ exports.getBeer = function(req, res) {
   // Use the Beer model to find a specific beer
   Beer.find({ userId: req.user._id, _id: req.params.beer_id }, function(err, beer) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json(beer);
   });
@@ -48,7 +48,7 @@ exports.putBeer = function(req, res) {
   // Use the Beer model to find a specific beer
   Beer.update({ userId: req.user._id, _id: req.params.beer_id }, { quantity: req.body.quantity }, function(err, num, raw) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json({ message: num + ' updated' });
   });
@@ -59,7 +59,7 @@ exports.deleteBeer = function(req, res) {
   // Use the Beer model to find a specific beer and remove it
   Beer.remove({ userId: req.user._id, _id: req.params.beer_id }, function(err) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json({ message: 'Beer removed from the locker!' });
   });

--- a/beerlocker-6.1/controllers/client.js
+++ b/beerlocker-6.1/controllers/client.js
@@ -15,7 +15,7 @@ exports.postClients = function(req, res) {
   // Save the client and check for errors
   client.save(function(err) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json({ message: 'Client added to the locker!', data: client });
   });
@@ -26,7 +26,7 @@ exports.getClients = function(req, res) {
   // Use the Client model to find all clients
   Client.find({ userId: req.user._id }, function(err, clients) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json(clients);
   });

--- a/beerlocker-6.1/controllers/user.js
+++ b/beerlocker-6.1/controllers/user.js
@@ -10,7 +10,7 @@ exports.postUsers = function(req, res) {
 
   user.save(function(err) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json({ message: 'New beer drinker added to the locker room!' });
   });
@@ -20,7 +20,7 @@ exports.postUsers = function(req, res) {
 exports.getUsers = function(req, res) {
   User.find(function(err, users) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json(users);
   });

--- a/beerlocker-6.1/server.js
+++ b/beerlocker-6.1/server.js
@@ -21,12 +21,13 @@ var app = express();
 app.set('view engine', 'ejs');
 
 // Use the body-parser package in our application
+app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({
   extended: true
 }));
 
 // Use express session support since OAuth2orize requires it
-app.use(session({ 
+app.use(session({
   secret: 'Super Secret Session Key',
   saveUninitialized: true,
   resave: true

--- a/beerlocker-6.2/controllers/beer.js
+++ b/beerlocker-6.2/controllers/beer.js
@@ -15,7 +15,7 @@ exports.postBeers = function(req, res) {
   // Save the beer and check for errors
   beer.save(function(err) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json({ message: 'Beer added to the locker!', data: beer });
   });
@@ -26,7 +26,7 @@ exports.getBeers = function(req, res) {
   // Use the Beer model to find all beer
   Beer.find({ userId: req.user._id }, function(err, beers) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json(beers);
   });
@@ -37,7 +37,7 @@ exports.getBeer = function(req, res) {
   // Use the Beer model to find a specific beer
   Beer.find({ userId: req.user._id, _id: req.params.beer_id }, function(err, beer) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json(beer);
   });
@@ -48,7 +48,7 @@ exports.putBeer = function(req, res) {
   // Use the Beer model to find a specific beer
   Beer.update({ userId: req.user._id, _id: req.params.beer_id }, { quantity: req.body.quantity }, function(err, num, raw) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json({ message: num + ' updated' });
   });
@@ -59,7 +59,7 @@ exports.deleteBeer = function(req, res) {
   // Use the Beer model to find a specific beer and remove it
   Beer.remove({ userId: req.user._id, _id: req.params.beer_id }, function(err) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json({ message: 'Beer removed from the locker!' });
   });

--- a/beerlocker-6.2/controllers/client.js
+++ b/beerlocker-6.2/controllers/client.js
@@ -15,7 +15,7 @@ exports.postClients = function(req, res) {
   // Save the client and check for errors
   client.save(function(err) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json({ message: 'Client added to the locker!', data: client });
   });
@@ -26,7 +26,7 @@ exports.getClients = function(req, res) {
   // Use the Client model to find all clients
   Client.find({ userId: req.user._id }, function(err, clients) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json(clients);
   });

--- a/beerlocker-6.2/controllers/user.js
+++ b/beerlocker-6.2/controllers/user.js
@@ -10,7 +10,7 @@ exports.postUsers = function(req, res) {
 
   user.save(function(err) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json({ message: 'New beer drinker added to the locker room!' });
   });
@@ -20,7 +20,7 @@ exports.postUsers = function(req, res) {
 exports.getUsers = function(req, res) {
   User.find(function(err, users) {
     if (err)
-      res.send(err);
+      return res.send(err);
 
     res.json(users);
   });

--- a/beerlocker-6.2/server.js
+++ b/beerlocker-6.2/server.js
@@ -21,12 +21,13 @@ var app = express();
 app.set('view engine', 'ejs');
 
 // Use the body-parser package in our application
+app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({
   extended: true
 }));
 
 // Use express session support since OAuth2orize requires it
-app.use(session({ 
+app.use(session({
   secret: 'Super Secret Session Key',
   saveUninitialized: true,
   resave: true


### PR DESCRIPTION
In every controller, errors are not returned directly, so a 'headers send twice' error can append.
Returning once error avoid this.

The json body parsing needs to be added to handle bodies in express, I guess.

ps. I've also add to update the mongoose version to 4.x, but this is more related to my installation (it's not in this pull request), anyway, upgrading works directly

double ps. thanks a lot for this (very very) detailed explainations
